### PR TITLE
Faster isNotEmpty on collection

### DIFF
--- a/lib/src/transformer/declaration_parsing.dart
+++ b/lib/src/transformer/declaration_parsing.dart
@@ -171,7 +171,7 @@ class ParsedDeclarations {
           }
         }
 
-        if (noneOfAnyRequiredDecl && declarations.length != 0) {
+        if (noneOfAnyRequiredDecl && declarations.isNotEmpty) {
           error(
               'To define a component, a `@$annotationName` must be accompanied by '
               'the following annotations within the same file: '


### PR DESCRIPTION
Use isNotEmpty instead (https://www.dartlang.org/guides/language/effective-dart/usage#dont-use-length-to-see-if-a-collection-is-empty)